### PR TITLE
Respect GITHUB_TOKEN when fetching via GithubReleaseProvider

### DIFF
--- a/src/GithubReleaseProvider.ts
+++ b/src/GithubReleaseProvider.ts
@@ -114,10 +114,18 @@ export class GithubReleaseProvider {
     const remoteReleases: GithubReleaseCollection = []
     do {
       info(`Fetching info for ${this.repo} releases page ${page}...`)
+      const init = process.env.GITHUB_TOKEN
+        ? {
+            headers: {
+              Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+            },
+          }
+        : undefined
       const url = `https://api.github.com/repos/${this.repo}/releases?per_page=100&page=${page}`
       const chunk = await smartFetch<GithubReleaseCollection>(
         url,
         this.cachePath()(`releases_page_${page}.json`),
+        init,
       )
       if (chunk.length === 0) break
       remoteReleases.push(...chunk)

--- a/src/util/smartFetch.ts
+++ b/src/util/smartFetch.ts
@@ -1,28 +1,31 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs'
-import fetch from 'node-fetch'
+import fetch, { RequestInit } from 'node-fetch'
 import { dirname } from 'path'
 import { dbg } from './log'
 import { mkPromiseSingleton } from './mkPromiseSingleton'
 import { mkdir } from './shell'
 import { stringify } from './stringify'
 
-const _fetch = mkPromiseSingleton(async <TRet>(url: string) => {
-  dbg(`Fetching ${url}`)
-  const res = await fetch(url)
-  if (res.status !== 200) {
-    throw new Error(`API appears to be down`)
-  }
-  const data = (await res.json()) as TRet
-  return data
-})
+const _fetch = mkPromiseSingleton(
+  async <TRet>(url: string, init?: RequestInit) => {
+    dbg(`Fetching ${url}`)
+    const res = await fetch(url, init)
+    if (res.status !== 200) {
+      throw new Error(`API appears to be down`)
+    }
+    const data = (await res.json()) as TRet
+    return data
+  },
+)
 
 export const smartFetch = async <TRet>(
   url: string,
   path: string,
+  init?: RequestInit,
 ): Promise<TRet> => {
   try {
     dbg(`Fetching`, url)
-    const data = await _fetch<TRet>(url)(url)
+    const data = await _fetch<TRet>(url)(url, init)
     mkdir('-p', dirname(path))
     writeFileSync(path, stringify(data))
     return data


### PR DESCRIPTION
Tried to use gobot at work. Got hit by rate limits (probably because there are other GitHub api callers in the building)

```
> Fetching info for pocketbase/pocketbase releases page 1...
> Error: API down and no cache https://api.github.com/repos/pocketbase/pocketbase/releases?per_page=100&page=1
```

The api returns a 403 status code with the following body.
```
{"message":"API rate limit exceeded for <redacted ip address>. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}
```

This patch checks the GITHUB_TOKEN environment variable and pass the Authorization header accordingly.

The convention of checking GITHUB_TOKEN is similar to GitHub CLI as documented in the [manual](https://cli.github.com/manual/) and, more familiarly to some, inside GitHub Actions.